### PR TITLE
Fetch validator handles every hour

### DIFF
--- a/api/src/ol/validators/validators.processor.ts
+++ b/api/src/ol/validators/validators.processor.ts
@@ -35,7 +35,7 @@ export class ValidatorsProcessor extends WorkerHost {
 
     await this.validatorsQueue.add('updateValidatorsHandlersCache', undefined, {
       repeat: {
-        every: 12 * 60 * 60 * 1000, // 12 hours
+        every: 1 * 60 * 60 * 1000, // 1 hour -- beware if this triggers github rate limits
       },
     });
 


### PR DESCRIPTION
Validator handles were being fetched every 24. This might be ok if things are working but if there's an error fetching (e.g. if the current validator handles json file has a syntax error) it then takes 24h to see the fixed handles. This PR reduces the polling interval to 1h.